### PR TITLE
Add message about artifact to and remove links from comment

### DIFF
--- a/smelly_python/generator/md_generator.py
+++ b/smelly_python/generator/md_generator.py
@@ -79,6 +79,8 @@ def generate_md(report: Report, explanations: ExplanationFetcher,
     else:
         result +=\
             get_block('You can find the more detailed html report in the artifact of the action.')
+        result +=\
+            get_block('On a PR, the artifact can be found at the right top of the `Checks` tab.')
         # table
         headers = ['', 'File', 'Lines', 'Smell', 'Explanation']
         data = [[

--- a/smelly_python/generator/md_generator.py
+++ b/smelly_python/generator/md_generator.py
@@ -6,7 +6,6 @@ from os import path
 
 from smelly_python.code_smell import Report
 from smelly_python.generator.pylint_explanation_fetcher import ExplanationFetcher
-from smelly_python.generator.webpage_generator import get_html_path
 
 
 def get_block(string):
@@ -16,16 +15,6 @@ def get_block(string):
     :return: the string as an MD block
     """
     return f'{string}\n\n'
-
-
-def get_link(label, url):
-    """
-    Formats a link to MD format.
-    :param: label the label to use for the link
-    :url: the url the link should point to
-    :return: the link in MD format
-    """
-    return f'[{label}]({url})'
 
 
 def get_table(headers, data):
@@ -79,10 +68,7 @@ def generate_md(report: Report, explanations: ExplanationFetcher,
     # summary
     result += get_block(
         '> Smelly Python found '
-        + get_link(
-            get_code_smell_number_string(len(report.code_smells)),
-            'smelly_python/index.html'
-        )
+        + get_code_smell_number_string(len(report.code_smells))
         + ' in your project.'
     )
 
@@ -91,15 +77,16 @@ def generate_md(report: Report, explanations: ExplanationFetcher,
         result += get_block('Good job! :partying_face:')
 
     else:
+        result +=\
+            get_block('You can find the more detailed html report in the artifact of the action.')
         # table
         headers = ['', 'File', 'Lines', 'Smell', 'Explanation']
         data = [[
             smell.type.value,
-            get_link(smell.location.path,
-                     path.join(output_path, get_html_path(smell.location.path))),
-            str(smell.location.line) + (
+            f'`{smell.location.path}`',
+            '`' + str(smell.location.line) + (
                 ':' + str(smell.location.column) if smell.location.column != 0 else ''
-            ),
+            ) + '`',
             smell.get_readable_symbol(),
             explanations.get_explanation(smell.message_id).to_markdown()
         ] for smell in report.code_smells]


### PR DESCRIPTION
We can't link to individual files in the artifact, nor to the artifact itself because github doesn't support it.

This PR removes the links and adds a message about the artifact instead.

An example of the new comment is:
# Smelly Python: 4.11/10

> Smelly Python found 13 code smells in your project.

You can find the more detailed html report in the artifact of the action.

|   | File | Lines | Smell | Explanation |
|---|------|-------|-------|-------------|
| :red_circle: | `test/code_smell_with_smells.py` | `58:20` | no value for parameter | Used when a function call passes too few arguments. [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#typecheck-checker-messages) |
| :red_circle: | `test/code_smell_with_smells.py` | `58:20` | no value for parameter | Used when a function call passes too few arguments. [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#typecheck-checker-messages) |
| :red_circle: | `test/code_smell_with_smells.py` | `58:20` | no value for parameter | Used when a function call passes too few arguments. [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#typecheck-checker-messages) |
| :red_circle: | `test/code_smell_with_smells.py` | `58:20` | no value for parameter | Used when a function call passes too few arguments. [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#typecheck-checker-messages) |
| :red_circle: | `test/code_smell_with_smells.py` | `136:23` | undefined variable | Used when an undefined variable is accessed. [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#variables-checker-messages) |
| :orange_circle: | `test/code_smell_with_smells.py` | `43:27` | unused argument | Used when a function or method argument is not used. [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#variables-checker-messages) |
| :orange_circle: | `test/code_smell_with_smells.py` | `43:33` | unused argument | Used when a function or method argument is not used. [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#variables-checker-messages) |
| :orange_circle: | `test/code_smell_with_smells.py` | `43:40` | unused argument | Used when a function or method argument is not used. [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#variables-checker-messages) |
| :orange_circle: | `test/code_smell_with_smells.py` | `43:49` | unused argument | Used when a function or method argument is not used. [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#variables-checker-messages) |
| :orange_circle: | `test/code_smell_with_smells.py` | `133:12` | pointless string statement | Used when a string is used as a statement (which of course has no effect). This is a particular case of W0104 with its own message so you can easily disable it if you're using those strings as documentation, instead of comments. [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#basic-checker-messages) |
| :yellow_circle: | `test/code_smell_with_smells.py` | `132:11` | comparison with itself | Used when something is compared against itself. [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#basic-checker-messages) |
| :large_blue_circle: | `test/code_smell_with_smells.py` | `43:49` | invalid name | Used when the name doesn't conform to naming rules associated to its type (constant, variable, class...). [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#basic-checker-messages) |
| :large_blue_circle: | `test/code_smell_with_smells.py` | `52` | invalid name | Used when the name doesn't conform to naming rules associated to its type (constant, variable, class...). [\[source\]](https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#basic-checker-messages) |


